### PR TITLE
suppressed fopen warning

### DIFF
--- a/src/Keboola/Csv/CsvFile.php
+++ b/src/Keboola/Csv/CsvFile.php
@@ -271,7 +271,7 @@ class CsvFile extends \SplFileInfo implements \Iterator
 			throw new Exception("Cannot open file $this",
 					Exception::FILE_NOT_EXISTS, NULL, 'fileNotExists');
 		}
-		$this->_filePointer = fopen($this->getPathname(), $mode);
+		$this->_filePointer = @fopen($this->getPathname(), $mode);
 		if (!$this->_filePointer) {
 			throw new Exception("Cannot open file $this",
 				Exception::FILE_NOT_EXISTS, NULL, 'fileNotExists');


### PR DESCRIPTION
When trying to write to a file that does not exist i.e `test/test.csv` `fopen` outputs the warning: 

```
PHP Warning:  fopen(test/test.csv): failed to open stream: No such file or directory in...
```

This is correct, but with you throwing an exception immediately after the `fopen` (if there is no file pointer) then i think it is safe to suppress this error (as you are handling it with the exception anyway). 
