### PR TITLE
Adds the ability to specify the newline char to use when writing a CSV file

### DIFF
--- a/src/Keboola/Csv/CsvFile.php
+++ b/src/Keboola/Csv/CsvFile.php
@@ -11,97 +11,109 @@ namespace Keboola\Csv;
 
 class CsvFile extends \SplFileInfo implements \Iterator
 {
-	const DEFAULT_DELIMITER = ',';
-	const DEFAULT_ENCLOSURE = '"';
-    const DEFAULT_NEWLINE   = "\n";
+    const DEFAULT_DELIMITER = ',';
+    const DEFAULT_ENCLOSURE = '"';
+    const DEFAULT_NEWLINE = "\n";
 
-	protected $_delimiter;
-	protected $_enclosure;
-	protected $_escapedBy;
+    protected $_delimiter;
+    protected $_enclosure;
+    protected $_escapedBy;
 
-	protected $_filePointer;
-	protected $_rowCounter  = 0;
-	protected $_currentRow;
-	protected $_lineBreak;
+    protected $_filePointer;
+    protected $_rowCounter = 0;
+    protected $_currentRow;
+    protected $_lineBreak;
     protected $_newline;
 
-	public function __construct(
+    public function __construct(
         $fileName,
         $delimiter = self::DEFAULT_DELIMITER,
         $enclosure = self::DEFAULT_ENCLOSURE,
         $escapedBy = "",
         $newline = self::DEFAULT_NEWLINE
     ) {
-		parent::__construct($fileName);
+        parent::__construct($fileName);
 
-		$this->_escapedBy = $escapedBy;
-		$this->_setDelimiter($delimiter);
-		$this->_setEnclosure($enclosure);
+        $this->_escapedBy = $escapedBy;
+        $this->_setDelimiter($delimiter);
+        $this->_setEnclosure($enclosure);
         $this->_setNewline($newline);
-	}
+    }
 
-	/**
-	 * @param $delimiter
-	 * @return CsvFile
-	 */
-	protected function _setDelimiter($delimiter)
-	{
-		$this->_validateDelimiter($delimiter);
-		$this->_delimiter = $delimiter;
-		return $this;
-	}
+    /**
+     * @param $delimiter
+     * @return CsvFile
+     */
+    protected function _setDelimiter($delimiter)
+    {
+        $this->_validateDelimiter($delimiter);
+        $this->_delimiter = $delimiter;
+        return $this;
+    }
 
-	protected function _validateDelimiter($delimiter)
-	{
-		if (strlen($delimiter) > 1) {
-			throw new InvalidArgumentException("Delimiter must be a single character. \"$delimiter\" received",
-				Exception::INVALID_PARAM, NULL, 'invalidParam');
-		}
+    protected function _validateDelimiter($delimiter)
+    {
+        if (strlen($delimiter) > 1) {
+            throw new InvalidArgumentException(
+                "Delimiter must be a single character. \"$delimiter\" received",
+                Exception::INVALID_PARAM,
+                null,
+                'invalidParam'
+            );
+        }
 
-		if (strlen($delimiter) == 0) {
-			throw new InvalidArgumentException("Delimiter cannot be empty.",
-				Exception::INVALID_PARAM, NULL, 'invalidParam');
-		}
-	}
+        if (strlen($delimiter) == 0) {
+            throw new InvalidArgumentException(
+                "Delimiter cannot be empty.",
+                Exception::INVALID_PARAM,
+                null,
+                'invalidParam'
+            );
+        }
+    }
 
-	public function getDelimiter()
-	{
-		return $this->_delimiter;
-	}
+    public function getDelimiter()
+    {
+        return $this->_delimiter;
+    }
 
-	public function getEnclosure()
-	{
-		return $this->_enclosure;
-	}
+    public function getEnclosure()
+    {
+        return $this->_enclosure;
+    }
 
-	public function getEscapedBy()
-	{
-		return $this->_escapedBy;
-	}
+    public function getEscapedBy()
+    {
+        return $this->_escapedBy;
+    }
 
     public function getNewline()
     {
         return $this->_newline;
     }
 
-	/**
-	 * @param $enclosure
-	 * @return CsvFile
-	 */
-	protected  function _setEnclosure($enclosure)
-	{
-		$this->_validateEnclosure($enclosure);
-		$this->_enclosure = $enclosure;
-		return $this;
-	}
+    /**
+     * @param $enclosure
+     * @return CsvFile
+     */
+    protected function _setEnclosure($enclosure)
+    {
+        $this->_validateEnclosure($enclosure);
+        $this->_enclosure = $enclosure;
+        return $this;
+    }
 
-	protected function _validateEnclosure($enclosure)
-	{
-		if (strlen($enclosure) > 1) {
-			throw new InvalidArgumentException("Enclosure must be a single character. \"$enclosure\" received",
-				Exception::INVALID_PARAM, NULL, 'invalidParam');
-		}
-	}
+    protected function _validateEnclosure($enclosure)
+    {
+        if (strlen($enclosure) > 1) {
+            throw new InvalidArgumentException(
+                "Enclosure must be a single character. \"$enclosure\" received",
+                Exception::INVALID_PARAM,
+                null,
+                'invalidParam'
+            );
+        }
+    }
 
     /**
      * @param $newline
@@ -117,205 +129,228 @@ class CsvFile extends \SplFileInfo implements \Iterator
     protected function _validateNewline($newline)
     {
         if (strlen($newline) <= 0 || strlen($newline) > 2) {
-            throw new InvalidArgumentException("Enclosure must be 1 or 2 characters long. \"$newline\" received",
-                Exception::INVALID_PARAM, NULL, 'invalidParam');
+            throw new InvalidArgumentException(
+                "Enclosure must be 1 or 2 characters long. \"$newline\" received",
+                Exception::INVALID_PARAM,
+                null,
+                'invalidParam'
+            );
         }
     }
 
-	public function getColumnsCount()
-	{
-		return count($this->getHeader());
-	}
+    public function getColumnsCount()
+    {
+        return count($this->getHeader());
+    }
 
-	public function getHeader()
-	{
-		$this->rewind();
-		$current = $this->current();
-		if (is_array($current)) {
-			return $current;
-		}
+    public function getHeader()
+    {
+        $this->rewind();
+        $current = $this->current();
+        if (is_array($current)) {
+            return $current;
+        }
 
-		return array();
-	}
+        return array();
+    }
 
-	public function writeRow(array $row)
-	{
-		$str = $this->rowToStr($row);
-		$ret = fwrite($this->_getFilePointer('w+'), $str);
+    public function writeRow(array $row)
+    {
+        $str = $this->rowToStr($row);
+        $ret = fwrite($this->_getFilePointer('w+'), $str);
 
-		/* According to http://php.net/fwrite the fwrite() function
-		 should return false on error. However not writing the full 
-		 string (which may occur e.g. when disk is full) is not considered 
-		 as an error. Therefore both conditions are necessary. */
-		if (($ret === false) || (($ret === 0) && (strlen($str) > 0)))  {
-				throw new Exception("Cannot open file $this",
-				Exception::WRITE_ERROR, NULL, 'writeError');
-		}
-	}
+        /* According to http://php.net/fwrite the fwrite() function
+         should return false on error. However not writing the full
+         string (which may occur e.g. when disk is full) is not considered
+         as an error. Therefore both conditions are necessary. */
+        if (($ret === false) || (($ret === 0) && (strlen($str) > 0))) {
+            throw new Exception(
+                "Cannot open file $this",
+                Exception::WRITE_ERROR,
+                null,
+                'writeError'
+            );
+        }
+    }
 
-	public function rowToStr(array $row)
-	{
-		$return = array();
-		foreach ($row as $column) {
-			$return[] = $this->getEnclosure()
-				. str_replace($this->getEnclosure(), str_repeat($this->getEnclosure(), 2), $column) . $this->getEnclosure();
-		}
-		return implode($this->getDelimiter(), $return) . $this->getNewline();
-	}
+    public function rowToStr(array $row)
+    {
+        $return = array();
+        foreach ($row as $column) {
+            $return[] = $this->getEnclosure()
+                . str_replace(
+                    $this->getEnclosure(),
+                    str_repeat($this->getEnclosure(), 2),
+                    $column
+                ) . $this->getEnclosure();
+        }
+        return implode($this->getDelimiter(), $return) . $this->getNewline();
+    }
 
-	public function getLineBreak()
-	{
-		if (!$this->_lineBreak) {
-			$this->_lineBreak = $this->_detectLineBreak();
-		}
-		return $this->_lineBreak;
-	}
+    public function getLineBreak()
+    {
+        if (!$this->_lineBreak) {
+            $this->_lineBreak = $this->_detectLineBreak();
+        }
+        return $this->_lineBreak;
+    }
 
-	public function getLineBreakAsText()
-	{
-		return trim(json_encode($this->getLineBreak()), '"');
-	}
+    public function getLineBreakAsText()
+    {
+        return trim(json_encode($this->getLineBreak()), '"');
+    }
 
-	public function validateLineBreak()
-	{
-		$lineBreak = $this->getLineBreak();
-		if (in_array($lineBreak, array("\r\n", "\n"))) {
-			return $lineBreak;
-		}
+    public function validateLineBreak()
+    {
+        $lineBreak = $this->getLineBreak();
+        if (in_array($lineBreak, array("\r\n", "\n"))) {
+            return $lineBreak;
+        }
 
-		throw new InvalidArgumentException("Invalid line break. Please use unix \\n or win \\r\\n line breaks.",
-			Exception::INVALID_PARAM, NULL, 'invalidParam');
-	}
+        throw new InvalidArgumentException(
+            "Invalid line break. Please use unix \\n or win \\r\\n line breaks.",
+            Exception::INVALID_PARAM,
+            null,
+            'invalidParam'
+        );
+    }
 
-	protected  function _detectLineBreak()
-	{
-		rewind($this->_getFilePointer());
-		$sample = fread($this->_getFilePointer(), 10000);
-		rewind($this->_getFilePointer());
+    protected function _detectLineBreak()
+    {
+        rewind($this->_getFilePointer());
+        $sample = fread($this->_getFilePointer(), 10000);
+        rewind($this->_getFilePointer());
 
-		$possibleLineBreaks = array(
-			"\r\n", // win
-			"\r", // mac
-			"\n", // unix
-		);
+        $possibleLineBreaks = array(
+            "\r\n", // win
+            "\r", // mac
+            "\n", // unix
+        );
 
-		$lineBreaksPositions = array();
-		foreach($possibleLineBreaks as $lineBreak) {
-			$position = strpos($sample, $lineBreak);
-			if ($position === false) {
-				continue;
-			}
-			$lineBreaksPositions[$lineBreak] = $position;
-		}
+        $lineBreaksPositions = array();
+        foreach ($possibleLineBreaks as $lineBreak) {
+            $position = strpos($sample, $lineBreak);
+            if ($position === false) {
+                continue;
+            }
+            $lineBreaksPositions[$lineBreak] = $position;
+        }
 
 
-		asort($lineBreaksPositions);
-		reset($lineBreaksPositions);
+        asort($lineBreaksPositions);
+        reset($lineBreaksPositions);
 
-		return empty($lineBreaksPositions) ? "\n" : key($lineBreaksPositions);
-	}
+        return empty($lineBreaksPositions) ? "\n" : key($lineBreaksPositions);
+    }
 
-	protected function _closeFile()
-	{
-		if (is_resource($this->_filePointer)) {
-			fclose($this->_filePointer);
-		}
-	}
+    protected function _closeFile()
+    {
+        if (is_resource($this->_filePointer)) {
+            fclose($this->_filePointer);
+        }
+    }
 
-	public function __destruct()
-	{
-		$this->_closeFile();
-	}
+    public function __destruct()
+    {
+        $this->_closeFile();
+    }
 
-	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
-	 * Return the current element
-	 * @link http://php.net/manual/en/iterator.current.php
-	 * @return mixed Can return any type.
-	 */
-	public function current()
-	{
-		return $this->_currentRow;
-	}
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * Return the current element
+     * @link http://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     */
+    public function current()
+    {
+        return $this->_currentRow;
+    }
 
-	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
-	 * Move forward to next element
-	 * @link http://php.net/manual/en/iterator.next.php
-	 * @return void Any returned value is ignored.
-	 */
-	public function next()
-	{
-		$this->_currentRow = $this->_readLine();
-		$this->_rowCounter++;
-	}
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * Move forward to next element
+     * @link http://php.net/manual/en/iterator.next.php
+     * @return void Any returned value is ignored.
+     */
+    public function next()
+    {
+        $this->_currentRow = $this->_readLine();
+        $this->_rowCounter++;
+    }
 
-	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
-	 * Return the key of the current element
-	 * @link http://php.net/manual/en/iterator.key.php
-	 * @return scalar scalar on success, integer
-	 * 0 on failure.
-	 */
-	public function key()
-	{
-		return $this->_rowCounter;
-	}
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * Return the key of the current element
+     * @link http://php.net/manual/en/iterator.key.php
+     * @return scalar scalar on success, integer
+     * 0 on failure.
+     */
+    public function key()
+    {
+        return $this->_rowCounter;
+    }
 
-	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
-	 * Checks if current position is valid
-	 * @link http://php.net/manual/en/iterator.valid.php
-	 * @return boolean The return value will be casted to boolean and then evaluated.
-	 * Returns true on success or false on failure.
-	 */
-	public function valid()
-	{
-		return $this->_currentRow !== false;
-	}
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * Checks if current position is valid
+     * @link http://php.net/manual/en/iterator.valid.php
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     */
+    public function valid()
+    {
+        return $this->_currentRow !== false;
+    }
 
-	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
-	 * Rewind the Iterator to the first element
-	 * @link http://php.net/manual/en/iterator.rewind.php
-	 * @return void Any returned value is ignored.
-	 */
-	public function rewind()
-	{
-		rewind($this->_getFilePointer());
-		$this->_currentRow = $this->_readLine();
-		$this->_rowCounter = 0;
-	}
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * Rewind the Iterator to the first element
+     * @link http://php.net/manual/en/iterator.rewind.php
+     * @return void Any returned value is ignored.
+     */
+    public function rewind()
+    {
+        rewind($this->_getFilePointer());
+        $this->_currentRow = $this->_readLine();
+        $this->_rowCounter = 0;
+    }
 
-	protected function _readLine()
-	{
-		$this->validateLineBreak();
+    protected function _readLine()
+    {
+        $this->validateLineBreak();
 
-		// allow empty enclosure hack
-		$enclosure = !$this->getEnclosure() ? chr(0) : $this->getEnclosure();
-		$escapedBy = !$this->_escapedBy ? chr(0) : $this->_escapedBy;
-		return fgetcsv($this->_getFilePointer(), null, $this->getDelimiter(), $enclosure, $escapedBy);
-	}
+        // allow empty enclosure hack
+        $enclosure = !$this->getEnclosure() ? chr(0) : $this->getEnclosure();
+        $escapedBy = !$this->_escapedBy ? chr(0) : $this->_escapedBy;
+        return fgetcsv($this->_getFilePointer(), null, $this->getDelimiter(), $enclosure, $escapedBy);
+    }
 
-	protected function _getFilePointer($mode = 'r')
-	{
-		if (!is_resource($this->_filePointer)) {
-			$this->_openFile($mode);
-		}
-		return $this->_filePointer;
-	}
+    protected function _getFilePointer($mode = 'r')
+    {
+        if (!is_resource($this->_filePointer)) {
+            $this->_openFile($mode);
+        }
+        return $this->_filePointer;
+    }
 
-	protected function _openFile($mode)
-	{
-		if ($mode == 'r' && !is_file($this->getPathname())) {
-			throw new Exception("Cannot open file $this",
-					Exception::FILE_NOT_EXISTS, NULL, 'fileNotExists');
-		}
-		$this->_filePointer = fopen($this->getPathname(), $mode);
-		if (!$this->_filePointer) {
-			throw new Exception("Cannot open file $this",
-				Exception::FILE_NOT_EXISTS, NULL, 'fileNotExists');
-		}
-	}
-
+    protected function _openFile($mode)
+    {
+        if ($mode == 'r' && !is_file($this->getPathname())) {
+            throw new Exception(
+                "Cannot open file $this",
+                Exception::FILE_NOT_EXISTS,
+                null,
+                'fileNotExists'
+            );
+        }
+        $this->_filePointer = fopen($this->getPathname(), $mode);
+        if (!$this->_filePointer) {
+            throw new Exception(
+                "Cannot open file $this",
+                Exception::FILE_NOT_EXISTS,
+                null,
+                'fileNotExists'
+            );
+        }
+    }
 }

--- a/src/Keboola/Csv/CsvFile.php
+++ b/src/Keboola/Csv/CsvFile.php
@@ -13,24 +13,31 @@ class CsvFile extends \SplFileInfo implements \Iterator
 {
 	const DEFAULT_DELIMITER = ',';
 	const DEFAULT_ENCLOSURE = '"';
+    const DEFAULT_NEWLINE   = "\n";
 
 	protected $_delimiter;
 	protected $_enclosure;
 	protected $_escapedBy;
 
 	protected $_filePointer;
-	protected $_rowCounter = 0;
+	protected $_rowCounter  = 0;
 	protected $_currentRow;
 	protected $_lineBreak;
+    protected $_newline;
 
-	public function __construct($fileName, $delimiter = self::DEFAULT_DELIMITER, $enclosure = self::DEFAULT_ENCLOSURE, $escapedBy = "")
-	{
+	public function __construct(
+        $fileName,
+        $delimiter = self::DEFAULT_DELIMITER,
+        $enclosure = self::DEFAULT_ENCLOSURE,
+        $escapedBy = "",
+        $newline = self::DEFAULT_NEWLINE
+    ) {
 		parent::__construct($fileName);
 
 		$this->_escapedBy = $escapedBy;
 		$this->_setDelimiter($delimiter);
 		$this->_setEnclosure($enclosure);
-
+        $this->_setNewline($newline);
 	}
 
 	/**
@@ -72,6 +79,11 @@ class CsvFile extends \SplFileInfo implements \Iterator
 		return $this->_escapedBy;
 	}
 
+    public function getNewline()
+    {
+        return $this->_newline;
+    }
+
 	/**
 	 * @param $enclosure
 	 * @return CsvFile
@@ -91,6 +103,24 @@ class CsvFile extends \SplFileInfo implements \Iterator
 		}
 	}
 
+    /**
+     * @param $newline
+     * @return CsvFile
+     */
+    protected function _setNewline($newline)
+    {
+        $this->_validateNewline($newline);
+        $this->_newline = $newline;
+        return $this;
+    }
+
+    protected function _validateNewline($newline)
+    {
+        if (strlen($newline) <= 0 || strlen($newline) > 2) {
+            throw new InvalidArgumentException("Enclosure must be 1 or 2 characters long. \"$newline\" received",
+                Exception::INVALID_PARAM, NULL, 'invalidParam');
+        }
+    }
 
 	public function getColumnsCount()
 	{
@@ -130,7 +160,7 @@ class CsvFile extends \SplFileInfo implements \Iterator
 			$return[] = $this->getEnclosure()
 				. str_replace($this->getEnclosure(), str_repeat($this->getEnclosure(), 2), $column) . $this->getEnclosure();
 		}
-		return implode($this->getDelimiter(), $return) . "\n";
+		return implode($this->getDelimiter(), $return) . $this->getNewline();
 	}
 
 	public function getLineBreak()

--- a/src/Keboola/Csv/Exception.php
+++ b/src/Keboola/Csv/Exception.php
@@ -11,50 +11,49 @@ namespace Keboola\Csv;
 
 class Exception extends \Exception
 {
-	const FILE_NOT_EXISTS = 1;
-	const INVALID_PARAM = 2;
-	const WRITE_ERROR = 3;
+    const FILE_NOT_EXISTS = 1;
+    const INVALID_PARAM = 2;
+    const WRITE_ERROR = 3;
 
-	protected $_stringCode;
+    protected $_stringCode;
 
-	protected $_contextParams;
+    protected $_contextParams;
 
-	public function __construct($message = null, $code = null, $previous = null, $stringCode = null, $params = null)
-	{
-		$this->setStringCode($stringCode);
-		$this->setContextParams($params);
-		parent::__construct($message, $code, $previous);
-	}
+    public function __construct($message = null, $code = null, $previous = null, $stringCode = null, $params = null)
+    {
+        $this->setStringCode($stringCode);
+        $this->setContextParams($params);
+        parent::__construct($message, $code, $previous);
+    }
 
 
-	public function getStringCode()
-	{
-		return $this->_stringCode;
-	}
+    public function getStringCode()
+    {
+        return $this->_stringCode;
+    }
 
-	/**
-	 * @param $stringCode
-	 * @return Exception
-	 */
-	public function setStringCode($stringCode)
-	{
-		$this->_stringCode = (string) $stringCode;
-		return $this;
-	}
+    /**
+     * @param $stringCode
+     * @return Exception
+     */
+    public function setStringCode($stringCode)
+    {
+        $this->_stringCode = (string)$stringCode;
+        return $this;
+    }
 
-	public function getContextParams()
-	{
-		return $this->_contextParams;
-	}
+    public function getContextParams()
+    {
+        return $this->_contextParams;
+    }
 
-	/**
-	 * @param array $contextParams
-	 * @return Exception
-	 */
-	public function setContextParams($contextParams)
-	{
-		$this->_contextParams = (array) $contextParams;
-		return $this;
-	}
-
+    /**
+     * @param array $contextParams
+     * @return Exception
+     */
+    public function setContextParams($contextParams)
+    {
+        $this->_contextParams = (array)$contextParams;
+        return $this;
+    }
 }

--- a/src/Keboola/Csv/InvalidArgumentException.php
+++ b/src/Keboola/Csv/InvalidArgumentException.php
@@ -11,5 +11,4 @@ namespace Keboola\Csv;
 
 class InvalidArgumentException extends Exception
 {
-
 }

--- a/tests/Keboola/Csv/CsvFileTest.php
+++ b/tests/Keboola/Csv/CsvFileTest.php
@@ -11,35 +11,34 @@ use Keboola\Csv\CsvFile;
 
 class Keboola_CsvFileTest extends PHPUnit_Framework_TestCase
 {
+    public function testExistingFileShouldBeCreated()
+    {
+        $this->assertInstanceOf('Keboola\Csv\CsvFile', new CsvFile(__DIR__ . '/_data/test-input.csv'));
+    }
 
-	public function testExistingFileShouldBeCreated()
-	{
-		$this->assertInstanceOf('Keboola\Csv\CsvFile', new CsvFile(__DIR__ . '/_data/test-input.csv'));
-	}
+    public function testExceptionShouldBeThrownOnNotExistingFile()
+    {
+        $this->setExpectedException('Keboola\Csv\Exception');
+        $csv = new CsvFile(__DIR__ . '/something.csv');
+        $csv->getHeader();
+    }
 
-	public function testExceptionShouldBeThrownOnNotExistingFile()
-	{
-		$this->setExpectedException('Keboola\Csv\Exception');
-		$csv = new CsvFile(__DIR__ . '/something.csv');
-		$csv->getHeader();
-	}
+    public function testColumnsCount()
+    {
+        $csv = new CsvFile(__DIR__ . '/_data/test-input.csv');
 
-	public function testColumnsCount()
-	{
-		$csv = new CsvFile(__DIR__ . '/_data/test-input.csv');
+        $this->assertEquals(9, $csv->getColumnsCount());
+    }
 
-		$this->assertEquals(9, $csv->getColumnsCount());
-	}
+    /**
+     * @dataProvider validCsvFiles
+     * @param $fileName
+     */
+    public function testRead($fileName, $delimiter)
+    {
+        $csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/' . $fileName, $delimiter, '"');
 
-	/**
-	 * @dataProvider validCsvFiles
-	 * @param $fileName
-	 */
-	public function testRead($fileName, $delimiter)
-	{
-		$csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/' . $fileName, $delimiter, '"');
-
-		$expected = array(
+        $expected = array(
             "id",
             "idAccount",
             "date",
@@ -49,112 +48,120 @@ class Keboola_CsvFileTest extends PHPUnit_Framework_TestCase
             "statuses",
             "kloutScore",
             "timestamp",
-		);
-		$this->assertEquals($expected, $csvFile->getHeader());
-	}
+        );
+        $this->assertEquals($expected, $csvFile->getHeader());
+    }
 
-	public function validCsvFiles()
-	{
-		return array(
-			array('test-input.csv', ','),
-			array('test-input.win.csv', ','),
-			array('test-input.tabs.csv', "\t"),
-			array('test-input.tabs.csv', "	"),
-		);
-	}
+    public function validCsvFiles()
+    {
+        return array(
+            array('test-input.csv', ','),
+            array('test-input.win.csv', ','),
+            array('test-input.tabs.csv', "\t"),
+            array('test-input.tabs.csv', "	"),
+        );
+    }
 
-	public function testParse()
-	{
-		$csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/escaping.csv', ",", '"');
+    public function testParse()
+    {
+        $csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/escaping.csv', ",", '"');
 
-		$rows = array();
-		foreach ($csvFile as $row) {
-			$rows[] = $row;
-		}
+        $rows = array();
+        foreach ($csvFile as $row) {
+            $rows[] = $row;
+        }
 
-		$expected = array(
-			array(
-				'col1', 'col2',
-			),
-			array(
-				'line without enclosure', 'second column',
-			),
-			array(
-				'enclosure " in column', 'hello \\',
-			),
-			array(
-				'line with enclosure', 'second column',
-			),
-			array(
-				'column with enclosure ", and comma inside text', 'second column enclosure in text "',
-			),
-			array(
-				"columns with\nnew line", "columns with\ttab",
-			),
-			array(
-				"Columns with WINDOWS\r\nnew line", "second",
-			),
-			array(
-				'column with \n \t \\\\', 'second col',
-			),
-		);
+        $expected = array(
+            array(
+                'col1',
+                'col2',
+            ),
+            array(
+                'line without enclosure',
+                'second column',
+            ),
+            array(
+                'enclosure " in column',
+                'hello \\',
+            ),
+            array(
+                'line with enclosure',
+                'second column',
+            ),
+            array(
+                'column with enclosure ", and comma inside text',
+                'second column enclosure in text "',
+            ),
+            array(
+                "columns with\nnew line",
+                "columns with\ttab",
+            ),
+            array(
+                "Columns with WINDOWS\r\nnew line",
+                "second",
+            ),
+            array(
+                'column with \n \t \\\\',
+                'second col',
+            ),
+        );
 
-		$this->assertEquals($expected, $rows);
-	}
+        $this->assertEquals($expected, $rows);
+    }
 
 
-	public function testEmptyHeader()
-	{
-		$csvFile = new CsvFile(__DIR__ . '/_data/test-input.empty.csv', ',', '"');
+    public function testEmptyHeader()
+    {
+        $csvFile = new CsvFile(__DIR__ . '/_data/test-input.empty.csv', ',', '"');
 
-		$this->assertEquals(array(), $csvFile->getHeader());
-	}
+        $this->assertEquals(array(), $csvFile->getHeader());
+    }
 
-	/**
-	 * @dataProvider invalidDelimiters
-	 * @expectedException Keboola\Csv\InvalidArgumentException
-	 * @param $delimiter
-	 */
-	public function testInvalidDelimiterShouldThrowException($delimiter)
-	{
-		new CsvFile(__DIR__ . '/_data/test-input.csv', $delimiter);
-	}
+    /**
+     * @dataProvider invalidDelimiters
+     * @expectedException Keboola\Csv\InvalidArgumentException
+     * @param $delimiter
+     */
+    public function testInvalidDelimiterShouldThrowException($delimiter)
+    {
+        new CsvFile(__DIR__ . '/_data/test-input.csv', $delimiter);
+    }
 
-	public function invalidDelimiters()
-	{
-		return array(
-			array('aaaa'),
-			array('ob g'),
-			array(''),
-		);
-	}
+    public function invalidDelimiters()
+    {
+        return array(
+            array('aaaa'),
+            array('ob g'),
+            array(''),
+        );
+    }
 
-	public function testInitInvalidFileShouldNotThrowException()
-	{
-		try {
-			$csvFile = new CsvFile(__DIR__ . '/_data/dafadfsafd.csv');
-		} catch (\Exception $e) {
-			$this->fail('Exception should not be thrown');
-		}
-	}
+    public function testInitInvalidFileShouldNotThrowException()
+    {
+        try {
+            $csvFile = new CsvFile(__DIR__ . '/_data/dafadfsafd.csv');
+        } catch (\Exception $e) {
+            $this->fail('Exception should not be thrown');
+        }
+    }
 
-	/**
-	 * @dataProvider invalidEnclosures
-	 * @expectedException Keboola\Csv\InvalidArgumentException
-	 * @param $enclosure
-	 */
-	public function testInvalidEnclosureShouldThrowException($enclosure)
-	{
-		new CsvFile(__DIR__ . '/_data/test-input.csv', ",", $enclosure);
-	}
+    /**
+     * @dataProvider invalidEnclosures
+     * @expectedException Keboola\Csv\InvalidArgumentException
+     * @param $enclosure
+     */
+    public function testInvalidEnclosureShouldThrowException($enclosure)
+    {
+        new CsvFile(__DIR__ . '/_data/test-input.csv', ",", $enclosure);
+    }
 
-	public function invalidEnclosures()
-	{
-		return array(
-			array('aaaa'),
-			array('ob g'),
-		);
-	}
+    public function invalidEnclosures()
+    {
+        return array(
+            array('aaaa'),
+            array('ob g'),
+        );
+    }
 
     /**
      * @dataProvider invalidNewlines
@@ -174,95 +181,101 @@ class Keboola_CsvFileTest extends PHPUnit_Framework_TestCase
         );
     }
 
-	/**
-	 * @param $file
-	 * @param $lineBreak
-	 * @dataProvider validLineBreaksData
-	 */
-	public function testLineEndingsDetection($file, $lineBreak, $lineBreakAsText)
-	{
-		$csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/' . $file);
-		$this->assertEquals($lineBreak, $csvFile->getLineBreak());
-		$this->assertEquals($lineBreakAsText, $csvFile->getLineBreakAsText());
-	}
+    /**
+     * @param $file
+     * @param $lineBreak
+     * @dataProvider validLineBreaksData
+     */
+    public function testLineEndingsDetection($file, $lineBreak, $lineBreakAsText)
+    {
+        $csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/' . $file);
+        $this->assertEquals($lineBreak, $csvFile->getLineBreak());
+        $this->assertEquals($lineBreakAsText, $csvFile->getLineBreakAsText());
+    }
 
-	public function validLineBreaksData()
-	{
-		return array(
-			array('test-input.csv', "\n",'\n'),
-			array('test-input.win.csv', "\r\n", '\r\n'),
-			array('escaping.csv', "\n", '\n'),
-			array('just-header.csv', "\n", '\n'), // default
-		);
-	}
+    public function validLineBreaksData()
+    {
+        return array(
+            array('test-input.csv', "\n", '\n'),
+            array('test-input.win.csv', "\r\n", '\r\n'),
+            array('escaping.csv', "\n", '\n'),
+            array('just-header.csv', "\n", '\n'), // default
+        );
+    }
 
-	/**
-	 * @expectedException Keboola\Csv\InvalidArgumentException
-	 * @dataProvider invalidLineBreaksData
-	 */
-	public function testInvalidLineBreak($file)
-	{
-		$csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/' . $file);
-		$csvFile->validateLineBreak();
-	}
+    /**
+     * @expectedException Keboola\Csv\InvalidArgumentException
+     * @dataProvider invalidLineBreaksData
+     */
+    public function testInvalidLineBreak($file)
+    {
+        $csvFile = new \Keboola\Csv\CsvFile(__DIR__ . '/_data/' . $file);
+        $csvFile->validateLineBreak();
+    }
 
-	public function invalidLineBreaksData()
-	{
-		return array(
-			array('test-input.mac.csv'),
-		);
-	}
+    public function invalidLineBreaksData()
+    {
+        return array(
+            array('test-input.mac.csv'),
+        );
+    }
 
 
-	public function testWrite()
-	{
-		$fileName = __DIR__ . '/_data/_out.csv';
-		if (file_exists($fileName)) {
-			unlink($fileName);
-		}
+    public function testWrite()
+    {
+        $fileName = __DIR__ . '/_data/_out.csv';
+        if (file_exists($fileName)) {
+            unlink($fileName);
+        }
 
-		$csvFile = new \Keboola\Csv\CsvFile($fileName);
+        $csvFile = new \Keboola\Csv\CsvFile($fileName);
 
-		$rows = array(
-			array(
-				'col1', 'col2',
-			),
-			array(
-				'line without enclosure', 'second column',
-			),
-			array(
-				'enclosure " in column', 'hello \\',
-			),
-			array(
-				'line with enclosure', 'second column',
-			),
-			array(
-				'column with enclosure ", and comma inside text', 'second column enclosure in text "',
-			),
-			array(
-				"columns with\nnew line", "columns with\ttab",
-			),
-			array(
-				'column with \n \t \\\\', 'second col',
-			)
-		);
+        $rows = array(
+            array(
+                'col1',
+                'col2',
+            ),
+            array(
+                'line without enclosure',
+                'second column',
+            ),
+            array(
+                'enclosure " in column',
+                'hello \\',
+            ),
+            array(
+                'line with enclosure',
+                'second column',
+            ),
+            array(
+                'column with enclosure ", and comma inside text',
+                'second column enclosure in text "',
+            ),
+            array(
+                "columns with\nnew line",
+                "columns with\ttab",
+            ),
+            array(
+                'column with \n \t \\\\',
+                'second col',
+            )
+        );
 
-		foreach ($rows as $row) {
-			$csvFile->writeRow($row);
-		}
+        foreach ($rows as $row) {
+            $csvFile->writeRow($row);
+        }
 
         $expectedFileContents =
-            "\"col1\",\"col2\"\n".
-            "\"line without enclosure\",\"second column\"\n".
-            "\"enclosure \"\" in column\",\"hello \\\"\n".
-            "\"line with enclosure\",\"second column\"\n".
-            "\"column with enclosure \"\", and comma inside text\",\"second column enclosure in text \"\"\"\n".
-            "\"columns with\nnew line\",\"columns with\ttab\"\n".
-            "\"column with \\n \\t \\\\\",\"second col\"\n"
-        ;
+            "\"col1\",\"col2\"\n" .
+            "\"line without enclosure\",\"second column\"\n" .
+            "\"enclosure \"\" in column\",\"hello \\\"\n" .
+            "\"line with enclosure\",\"second column\"\n" .
+            "\"column with enclosure \"\", and comma inside text\",\"second column enclosure in text \"\"\"\n" .
+            "\"columns with\nnew line\",\"columns with\ttab\"\n" .
+            "\"column with \\n \\t \\\\\",\"second col\"\n";
 
         $this->assertEquals($expectedFileContents, file_get_contents($fileName));
-	}
+    }
 
     public function testWriteWithWindowsNewline()
     {
@@ -275,25 +288,32 @@ class Keboola_CsvFileTest extends PHPUnit_Framework_TestCase
 
         $rows = array(
             array(
-                'col1', 'col2',
+                'col1',
+                'col2',
             ),
             array(
-                'line without enclosure', 'second column',
+                'line without enclosure',
+                'second column',
             ),
             array(
-                'enclosure " in column', 'hello \\',
+                'enclosure " in column',
+                'hello \\',
             ),
             array(
-                'line with enclosure', 'second column',
+                'line with enclosure',
+                'second column',
             ),
             array(
-                'column with enclosure ", and comma inside text', 'second column enclosure in text "',
+                'column with enclosure ", and comma inside text',
+                'second column enclosure in text "',
             ),
             array(
-                "columns with\nnew line", "columns with\ttab",
+                "columns with\nnew line",
+                "columns with\ttab",
             ),
             array(
-                'column with \n \t \\\\', 'second col',
+                'column with \n \t \\\\',
+                'second col',
             )
         );
 
@@ -302,48 +322,47 @@ class Keboola_CsvFileTest extends PHPUnit_Framework_TestCase
         }
 
         $expectedFileContents =
-            "\"col1\",\"col2\"\r\n".
-            "\"line without enclosure\",\"second column\"\r\n".
-            "\"enclosure \"\" in column\",\"hello \\\"\r\n".
-            "\"line with enclosure\",\"second column\"\r\n".
-            "\"column with enclosure \"\", and comma inside text\",\"second column enclosure in text \"\"\"\r\n".
-            "\"columns with\nnew line\",\"columns with\ttab\"\r\n".
-            "\"column with \\n \\t \\\\\",\"second col\"\r\n"
-        ;
+            "\"col1\",\"col2\"\r\n" .
+            "\"line without enclosure\",\"second column\"\r\n" .
+            "\"enclosure \"\" in column\",\"hello \\\"\r\n" .
+            "\"line with enclosure\",\"second column\"\r\n" .
+            "\"column with enclosure \"\", and comma inside text\",\"second column enclosure in text \"\"\"\r\n" .
+            "\"columns with\nnew line\",\"columns with\ttab\"\r\n" .
+            "\"column with \\n \\t \\\\\",\"second col\"\r\n";
 
         $this->assertEquals($expectedFileContents, file_get_contents($fileName));
     }
 
-	public function testIterator()
-	{
-		$csvFile = new CsvFile(__DIR__ . '/_data/test-input.csv');
+    public function testIterator()
+    {
+        $csvFile = new CsvFile(__DIR__ . '/_data/test-input.csv');
 
-		$expected = array(
-			"id",
-			"idAccount",
-			"date",
-			"totalFollowers",
-			"followers",
-			"totalStatuses",
-			"statuses",
-			"kloutScore",
-			"timestamp",
-		);
+        $expected = array(
+            "id",
+            "idAccount",
+            "date",
+            "totalFollowers",
+            "followers",
+            "totalStatuses",
+            "statuses",
+            "kloutScore",
+            "timestamp",
+        );
 
-		// header line
-		$csvFile->rewind();
-		$this->assertEquals($expected, $csvFile->current());
+        // header line
+        $csvFile->rewind();
+        $this->assertEquals($expected, $csvFile->current());
 
-		// first line
-		$csvFile->next();
-		$this->assertTrue($csvFile->valid());
+        // first line
+        $csvFile->next();
+        $this->assertTrue($csvFile->valid());
 
-		// second line
-		$csvFile->next();
-		$this->assertTrue($csvFile->valid());
+        // second line
+        $csvFile->next();
+        $this->assertTrue($csvFile->valid());
 
-		// file end
-		$csvFile->next();
-		$this->assertFalse($csvFile->valid());
-	}
+        // file end
+        $csvFile->next();
+        $this->assertFalse($csvFile->valid());
+    }
 }


### PR DESCRIPTION
I was using your code to generate CSVs in a project. The customer asked for a CSV with a \r\n newline sequence, so I thought I'd create a pull request in case anyone else is interested. Unit tests for the new feature are included.

The first commit is the one that actually adds the new feature (and tests). The second commit is just a code reformat. Among other things it replaces all of the tab indentations with space indentations, so in the diff it looks like almost everything was rewritten.
