### PR TITLE
Updates for php 8.1 compatibility

### DIFF
--- a/src/CsvReader.php
+++ b/src/CsvReader.php
@@ -165,7 +165,7 @@ class CsvReader extends AbstractCsvFile implements Iterator
     /**
      * @inheritdoc
      */
-    public function rewind()
+    public function rewind() : void
     {
         rewind($this->getFilePointer());
         for ($i = 0; $i < $this->skipLines; $i++) {
@@ -213,7 +213,7 @@ class CsvReader extends AbstractCsvFile implements Iterator
     /**
      * @inheritdoc
      */
-    public function current()
+    public function current() : mixed
     {
         return $this->currentRow;
     }
@@ -221,7 +221,7 @@ class CsvReader extends AbstractCsvFile implements Iterator
     /**
      * @inheritdoc
      */
-    public function next()
+    public function next() : void
     {
         $this->currentRow = $this->readLine();
         $this->rowCounter++;
@@ -230,7 +230,7 @@ class CsvReader extends AbstractCsvFile implements Iterator
     /**
      * @inheritdoc
      */
-    public function key()
+    public function key() : mixed
     {
         return $this->rowCounter;
     }
@@ -238,7 +238,7 @@ class CsvReader extends AbstractCsvFile implements Iterator
     /**
      * @inheritdoc
      */
-    public function valid()
+    public function valid() : bool
     {
         return $this->currentRow !== false;
     }


### PR DESCRIPTION
I'm getting this warning when running this code in php 8.1:

`Deprecated function: Return type of Keboola\Csv\CsvReader::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 5 of /var/www/vendor/keboola/csv/src/CsvReader.php).`

This PR sets the return types of CsvReader to match that of Iterator in order to get rid of these warnings.